### PR TITLE
use universalized package name in run_dev.py

### DIFF
--- a/run_dev.py
+++ b/run_dev.py
@@ -1,4 +1,4 @@
-from wowfunding.factory import create_app
+from funding.factory import create_app
 import settings
 
 if __name__ == '__main__':


### PR DESCRIPTION
Needed to start after module name was changed in e4aa5e0f0fc56cf9e316e05da4ae47b0602dec4e