### PR TITLE
remove padding from .bg-dark navbar

### DIFF
--- a/funding/static/css/aeon.css
+++ b/funding/static/css/aeon.css
@@ -117,7 +117,7 @@ body {
     -moz-border-radius: 0;
     border-radius: 0;
     border: none;
-    padding: 5px 0;}
+}
 
 .navbar-dark .navbar-brand {
     color: #fff;


### PR DESCRIPTION
this restores standard padding so that brand and button are not at the corner anymore on mobile view.